### PR TITLE
Update to latest Cake and NSwag Versions

### DIFF
--- a/src/Cake.CodeGen.NSwag/Cake.CodeGen.NSwag.csproj
+++ b/src/Cake.CodeGen.NSwag/Cake.CodeGen.NSwag.csproj
@@ -15,11 +15,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="0.33.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
-    <PackageReference Include="NSwag.CodeGeneration.CSharp" Version="13.0.3" />
-    <PackageReference Include="NSwag.CodeGeneration.TypeScript" Version="13.0.3" />
-    <PackageReference Include="NSwag.Core.Yaml" Version="13.0.3" />
+    <PackageReference Include="Cake.Common" Version="1.1.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="1.1.0" PrivateAssets="All" />
+    <PackageReference Include="NSwag.CodeGeneration.CSharp" Version="13.10.8" />
+    <PackageReference Include="NSwag.CodeGeneration.TypeScript" Version="13.10.8" />
+    <PackageReference Include="NSwag.Core.Yaml" Version="13.10.8" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is a simple PR to update the referenced dependencies of NSwag and Cake Core to the latest in order to support Cake v1.0.